### PR TITLE
Add Terralist to the Self-Hosted Registries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-simple-registry](https://github.com/apparentlymart/terraform-simple-registry) - Simple implementation of the Terraform registry protocols.
 - [Terrareg](https://github.com/matthewjohn/terrareg) - Terraform module registry.
 - [terustry](https://github.com/veepee-oss/terustry) - Open Source terraform provider registry acting as a proxy for gitlab or github releases.
+- [terralist](https://github.com/terralist/terralist) - Terraform Private Registry for modules and providers manageable from a REST API.
 
 ## Managed Registries
 


### PR DESCRIPTION
Terralist is a self-hosted private registry I created a while back and IMO it matured enough to be included in this list.