### PR TITLE
Add terraform-provider-uname to the list of Community Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-docker](https://github.com/kreuzwerker/terraform-provider-docker) - Terraform Docker provider.
 - [terraform-provider-terracurl](https://github.com/devops-rob/terraform-provider-terracurl) - Provider to make managed and unmanaged API calls to your target endpoint.
 - [terraform-provider-value](https://github.com/pseudo-dynamic/terraform-provider-value) - Value Provider for Terraform.
+- [terraform-provider-uname](https://github.com/julienlevasseur/terraform-provider-uname) - Uname Provider for Terraform.
 
 ## Testing
 


### PR DESCRIPTION
This PR propose the addition of the `terraform-provider-uname` (https://github.com/julienlevasseur/terraform-provider-uname) to the list of Community Providers.