### PR TITLE
add tfmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tfvar](https://github.com/shihanng/tfvar) - tfvar scans your Terraform configurations or modules and extracts the variables into formats of your choice (tfvar, environment variables, etc.) for editing.
 - [tfvaultenv](https://github.com/oulman/tfvaultenv) - tfvaultenv reads secrets from HashiCorp Vault and outputs environment variables for various Terraform providers with those secrets.
 - [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely.
+- [tfmcp](https://github.com/nwiizo/tfmcp) - A CLI tool that helps you interact with Terraform via the Model Context Protocol (MCP), allowing AI assistants like Claude to manage and operate Terraform environments.
 - [tgf](https://github.com/coveooss/tgf) - Terragrunt frontend for executing Terragrunt/Terraform through Docker.
 - [threatcl](https://github.com/threatcl/threatcl) - Documenting your Threat Models with HCL
 - [tofuenv](https://github.com/tofuutils/tofuenv) - OpenTofu version manager inspired by tfenv


### PR DESCRIPTION
This PR adds information about tfmcp, a command-line tool that enables LLMs to manage and operate Terraform environments through the Model Context Protocol (MCP).

## Description

tfmcp is an experimental command-line tool that allows AI assistants like Claude to interact with Terraform via the Model Context Protocol. It enables reading configuration files, analyzing plan outputs, applying configurations, managing state, and creating or modifying Terraform infrastructure as code.

## References

- GitHub repository: https://github.com/nwiizo/tfmcp
- Japanese blog post: https://syu-m-5151.hatenablog.com/entry/2025/03/09/020057

## Testing

Verified documentation accuracy against the current README and confirmed installation steps work properly.

Let me know if you'd like me to make any adjustments to this PR description!