### PR TITLE
Add TerraForce to Tools Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [TerraDepot](https://github.com/derBroBro/TerraDepot) Terraform state repository, based on the default http remote backend. Allows the central administration of tfstates on AWS S3.
 - [terradozer](https://github.com/jckuester/terradozer) - Terraform destroy without configuration files.
 - [terraeasy](https://github.com/jaceq/terraeasy) - Easy Terraform wrapper
+- [TerraForce](https://terraforce.henrybravo.nl) - A policy enforcement tool for Terraform that ensures consistency and compliance through lifecycle policy checks, flexible policy definitions, and CI/CD integration.
 - [terraform-aws-clickops-notifier](https://github.com/cloudandthings/terraform-aws-clickops-notifier) - Get notified when actions are taken in the AWS Console.
 - [terraform-bundle](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle) - Easily builds bundles containing a Terraform binary as well as provider binaries. Useful for CI and air-gapped Terraform Enterprise.
 - [terraform-cdk](https://github.com/hashicorp/terraform-cdk) - CDK (Cloud Development Kit) for Terraform allows developers to use familiar programming languages to define cloud infrastructure and provision it through HashiCorp Terraform.


### PR DESCRIPTION
This pull request adds TerraForce to the Tools section of awesome-terraform. TerraForce is a policy enforcement tool for Terraform that helps teams maintain consistency and compliance through lifecycle policy checks, flexible policy definitions using Go templates and YAML and seamless CI/CD integration.

Entry added:
- [TerraForce](https://terraforce.henrybravo.nl) - A policy enforcement tool for Terraform that ensures consistency and compliance through lifecycle policy checks, flexible policy definitions, CI/CD integration, and built-in testing.

Please let me know if any changes are needed!