### PR TITLE
tools: Add tfvault

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [tftui](https://github.com/idoavrah/terraform-tui) - A textual user interface for Terraform state.
 - [tfupdate](https://github.com/minamijoyo/tfupdate) - Update version constraints in your Terraform configurations.
 - [tfvar](https://github.com/shihanng/tfvar) - tfvar scans your Terraform configurations or modules and extracts the variables into formats of your choice (tfvar, environment variables, etc.) for editing.
+- [tfvault](https://github.com/tedilabs/tfvault) - Universal Terraform credentials helper with pluggable secret backends (OS keyring, pass/gopass, environment variables) and per-profile account isolation.
 - [tfvaultenv](https://github.com/oulman/tfvaultenv) - tfvaultenv reads secrets from HashiCorp Vault and outputs environment variables for various Terraform providers with those secrets.
 - [tfwrapper](https://github.com/manheim/tfwrapper) - Rubygem providing rake tasks for running Hashicorp Terraform sanely.
 - [tfmcp](https://github.com/nwiizo/tfmcp) - A CLI tool that helps you interact with Terraform via the Model Context Protocol (MCP), allowing AI assistants like Claude to manage and operate Terraform environments.


### PR DESCRIPTION
Adds [tfvault](https://github.com/tedilabs/tfvault) to the Tools section (alphabetical position, after `tfvar`).

tfvault is a universal Terraform [credentials helper](https://developer.hashicorp.com/terraform/internals/credentials-helpers) with pluggable secret backends — OS keyring, pass/gopass, environment variables — and per-profile isolation so multiple accounts on one machine don't share token storage. Apache-2.0, macOS/Linux, distributed via Homebrew tap / install script / mise.