### PR TITLE
tools: add bare-devcontainer/templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [aws2tf](https://github.com/aws-samples/aws2tf) - automates the importing of existing AWS resources into Terraform and outputs the Terraform HCL code.
 - [aztfexport](https://github.com/Azure/aztfexport) - A tool to bring existing Azure resources under Terraform's management.
 - [balcony](https://oguzhan-yilmaz.github.io/balcony/) - CLI tool for easy AWS API reads. Also generates Terraform import-blocks, and actual Terraform Resource code.
+- [bare-devcontainer/templates](https://github.com/bare-devcontainer/templates/tree/main/src/terraform) - Security-focused Terraform dev container with terraform-ls and rebuild-friendly caching. The base image is available at [bare-devcontainer/images](https://github.com/bare-devcontainer/images/tree/main/terraform).
 - [blast radius](https://github.com/28mm/blast-radius) - Interactive visualizations of Terraform dependency graphs. :skull:
 - [cf-terraforming](https://github.com/cloudflare/cf-terraforming) - A command line utility to facilitate terraforming your existing Cloudflare resources.
 - [cfnctl](https://github.com/rogerwelin/cfnctl) - Cfnctl brings the Terraform cli experience to AWS Cloudformation.


### PR DESCRIPTION
This PR adds [Bare Dev Container Templates](https://github.com/bare-devcontainer/templates/tree/main/src) to the list.

The collection includes a security-focused Terraform development container that provides:

* Terraform CLI and `terraform-ls`
* Official HashiCorp VS Code extensions and format-on-save configuration
* A persistent Terraform provider plugin cache
* A non-root development environment with reduced container privileges
* Minimal base images designed to reduce supply-chain risk and attack surface

It provides a reproducible, ready-to-use development environment for Terraform projects in VS Code, GitHub Codespaces, and other Dev Container-compatible tools.