### PR TITLE
providers: Add elevenode App Store Connect and Expo providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-openrouter](https://github.com/cloudopsworks/terraform-provider-openrouter) - Manage OpenRouter as code: workspaces, guardrails, spend-limited API keys, and org members. Terraform + OpenTofu.
 - [terraform-provider-plancost](https://github.com/plancost/terraform-provider-plancost) - Terraform provider for Azure cost estimation and cost guardrails.
 - [terraform-provider-coolify](https://github.com/coolify-terraform/terraform-provider-coolify) - Terraform provider for Coolify.
+- [terraform-provider-appstore](https://github.com/elevenode/terraform-provider-appstore) - Terraform provider for Apple App Store Connect.
+- [terraform-provider-expo](https://github.com/elevenode/terraform-provider-expo) - Terraform provider for Expo Application Services (EAS).
 
 ## Testing
 


### PR DESCRIPTION
Adds two open-source (Apache 2.0) community providers to the Community providers list:

- [terraform-provider-appstore](https://github.com/elevenode/terraform-provider-appstore) — manage Apple App Store Connect bundle identifiers, provisioning profiles, and certificates as code.
- [terraform-provider-expo](https://github.com/elevenode/terraform-provider-expo) — manage Expo Application Services (EAS) apps, credentials, environment variables, and update channels as code.

Both are published on the Terraform Registry (`elevenode/appstore`, `elevenode/expo`). Entries follow the existing format and are appended to the Community providers section.