### PR TITLE
tools: add AzureNamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [atmos](https://github.com/cloudposse/atmos) - A universal tool that converts deep merged YAML to module inputs.
 - [aws2tf](https://github.com/aws-samples/aws2tf) - automates the importing of existing AWS resources into Terraform and outputs the Terraform HCL code.
 - [aztfexport](https://github.com/Azure/aztfexport) - A tool to bring existing Azure resources under Terraform's management.
+- [AzureNamer](https://azurenamingconventions.com/) - Generates CAF compliant names for 200+ Azure resource types and exports them as Terraform locals, with live length and character validation.
 - [balcony](https://oguzhan-yilmaz.github.io/balcony/) - CLI tool for easy AWS API reads. Also generates Terraform import-blocks, and actual Terraform Resource code.
 - [blast radius](https://github.com/28mm/blast-radius) - Interactive visualizations of Terraform dependency graphs. :skull:
 - [cf-terraforming](https://github.com/cloudflare/cf-terraforming) - A command line utility to facilitate terraforming your existing Cloudflare resources.


### PR DESCRIPTION
Adds AzureNamer to the Tools list.

It is a free, no-login web tool that generates CAF compliant Azure resource names for 200+ resource types with live length and character validation, then exports them as Terraform locals (also Bicep, JSON, CSV). Useful for anyone writing Terraform for Azure who wants consistent, rule-valid resource names.

Placed alphabetically after aztfexport. One-line addition, no other changes.