### PR TITLE
self-hosted-platform: add snapcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 
 ## Self-hosted Terraform Platforms
 
+- [Snap CD](https://github.com/schrieksoft/snapcd) - Fully-featured continuous deployment platform that facilitates modular deployments with isolated runners, dependency-aware automation, and fine-grained access control.
 - [Lynx](https://github.com/clivern/lynx) - Fast, Secure and Reliable Terraform Backend. It has a user-friendly dashboard, project and environment management, state versioning, locking and snapshots support.
 - [OTF](https://github.com/leg100/otf) - Open Terraforming Framework, an open source alternative to Terraform Enterprise with full Terraform CLI integration.
 - [Terrakube](https://docs.terrakube.io) - Open Source alternative to Terraform Enterprise with private registry, remote state, custom flows, scheduled workspaces, and visual states.


### PR DESCRIPTION
Snap CD is a fully-featured continuous deployment platform that facilitates modular deployments with isolated runners, dependency-aware automation, and fine-grained access control. Its main goal is to make it easy break up terraform monoliths into smaller, standalone states (modules), without losing the dependency management.

Available on GitHub [here](https://github.com/schrieksoft/snapcd).

A full writeup on why I created this can be found [here](https://snapcd.io/Blog/introducing-snapcd).

A few features worth flagging:
- A comprehensive event-driven architecture means separate terraform/tofu states can be kept in sync automatically. Typical events include new commits to monitored branch, or outputs from an upstream module changing.
- The architecture splits control plane (Server) from execution (Runner). Multple runners can be joined to the server
- Runners can be isolated to be usable only by certain resources/teams
- All resources and actions are governed by an extensive RBAC system
- Approval workflows allow you to scrutize `plan` results before applying
- Very extensive CRUD API (with RBAC system plugged into it) can be interacted with by Users or Service Principals (authenticated via OIDC)
- Integrations (e.g. Slack) can be subscribed to system events and are automatically informed.
- An AI "mission" framework allows for automatic diagnoses/fixes of failed jobs (but very tightly controlled)
- All resources can be managed via UI, API or the [terrraform provider](https://registry.terraform.io/providers/schrieksoft/snapcd/latest/docs)
-  Can be deployed in a matter of minutes, e.g. via the [sample docker deployment](https://github.com/schrieksoft/snapcd-deployment-docker) and the [sample project](https://github.com/snapcd-samples/sample-deployment) works against that deployment out of the box
- Extensive docs are hosted at [docs.snapcd.io](https://docs.snapcd.io).
