### PR TITLE
Add demonolith

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI with remediation engine that generates Terraform code for fixing misconfigurations.
 - [Coder](https://coder.com/) - Coder provisions software development environments on your infrastructure via Terraform.
 - [coretech/terrafile](https://github.com/coretech/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Go). :skull:
+- [demonolith](https://github.com/schrieksoft/demonolith) - Splits up monolithic Terraform projects with `demonolith refactor` (to move the code) and `demonolith migrate` (to migrate into smaller .tfstate files).
 - [driftctl](https://github.com/snyk/driftctl) - Detect, track, and alert on infrastructure drift :skull:
 - [drifthound](https://github.com/drifthoundhq/drifthound) - Continuous infrastructure drift detection with historical tracking and notifications.
 - [dxw/terrafile](https://github.com/dxw/terrafile) - Systematically manage external modules from Github for use in Terraform (written in Ruby).


### PR DESCRIPTION
`demonolith` is a Go CLI that splits a Terraform/OpenTofu monolith into separate per-module roots.

Available on GitHub [here](https://github.com/schrieksoft/demonolith).

A full writeup on how it works is here [here](https://snapcd.io/Blog/automating-terraform-monolith-split).

How it works, roughly:

- There is no migration script to write. You annotate the monolith with `# @demono:move <module>` comments saying which root each block should end up in.
- The `demonolith refactor` (code refactoring) and `demonolith migrate` (state migration) steps are separate command families. The refactor is offline and undoable with git. The state migration is not, so it sits behind a prove step.
- The prove step plans every new module against a local copy of its state. All plans must come back with zero changes before anything gets pushed.
- The original monolith state is never touched. Retiring the monolith is a decision you make yourself, later.
- There is a [sample project](https://github.com/snapcd-samples/sample-deployment-demonolith) you can run the whole thing against end to end, no cloud account needed.