### PR TITLE
learning: Add Terraform Terminal Simulator to Learning and Studying

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Terraform enables you to safely and predictably create, change, and improve prod
 ## Learning and Studying
 
 - [Terraform Academy](https://www.terraformacademy.app) - Interactive Terraform / IaC learning platform with hands-on labs, certification prep (HashiCorp, AWS, GCP, Azure, Docker, Kubernetes, GitOps), AI coaching, and progress tracking. See also the [SRE Pro Tips blog](https://www.terraformacademy.app/protips/?cat=sre-pro-tips) and the mobile/PWA apps below.
+- [Terraform Terminal Simulator](https://devops-daily.com/games/terraform-terminal-simulator) - Practice init, plan, and apply in a simulated terminal in the browser. Free and open source, no signup.
 - [compliance.tf docs](https://compliance.tf/docs/) - Free Terraform implementations of SOC 2, PCI DSS, HIPAA, NIST 800-53, and 35+ other compliance controls — open reference for writing compliant infrastructure code.
 
 ## Apps


### PR DESCRIPTION
Adds the Terraform Terminal Simulator to Learning and Studying: guided init/plan/apply lessons in a simulated terminal in the browser, free with no signup, from the open source DevOps Daily project (https://github.com/The-DevOps-Daily/devops-daily).

Disclosure: I help maintain the site.
