### PR TITLE
modules: Add terraform-helm-kepler

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-ecs-jenkins](https://github.com/shuaibiyy/terraform-ecs-jenkins) - Provisions Jenkins on AWS ECS using Terraform.
 - [terraform-gce-atlantis](https://github.com/runatlantis/terraform-gce-atlantis) - Creates Terraform configurations for running [Atlantis](https://runatlantis.io) on Google Compute Engine.
 - [terraform-google-project-factory](https://github.com/terraform-google-modules/terraform-google-project-factory) - Opinionated Google Cloud Platform project creation and configuration with Shared VPC, IAM, APIs, etc.
+- [terraform-helm-kepler](https://github.com/fabiocicerchia/terraform-helm-kepler) - Terraform module to deploy Kepler (Kubernetes power profiling) via Helm.
 - [terraform-kubestack](https://github.com/kbst/terraform-kubestack) - Kubestack is a framework for Kubernetes platform engineering teams to define the entire cloud native stack in one Terraform code base and continuously evolve the platform safely through GitOps.
 - [terraform-linode-k8s](https://registry.terraform.io/modules/linode/k8s/linode/latest) - Installs Kubernetes on Linode Instances.
 - [terraform-nixos](https://github.com/nix-community/terraform-nixos) - A set of Terraform modules that are designed to deploy NixOS.


### PR DESCRIPTION
Adds [terraform-helm-kepler](https://github.com/fabiocicerchia/terraform-helm-kepler) under **Community Modules**.

> Terraform module to deploy Kepler (Kubernetes power profiling) via Helm.

One addition in a single commit, formatted and ordered to match the surrounding entries in that section.