### PR TITLE
providers: add terraform-provider-seekrit

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-appstore](https://github.com/elevenode/terraform-provider-appstore) - Terraform provider for Apple App Store Connect.
 - [terraform-provider-expo](https://github.com/elevenode/terraform-provider-expo) - Terraform provider for Expo Application Services (EAS).
 - [terraform-provider-paddle](https://github.com/vivantel/terraform-provider-paddle) - Terraform provider for Paddle Billing catalog resources, lifecycle actions, and lookup data sources.
+- [terraform-provider-seekrit](https://github.com/seekritdev/terraform-provider-seekrit) - Manage seekrit apps, environments, groups, service tokens, key grants and secrets. Write-only arguments and ephemeral resources keep secret values out of state.
 
 ## Testing
 


### PR DESCRIPTION
Adds [terraform-provider-seekrit](https://github.com/seekritdev/terraform-provider-seekrit) at the bottom of **Community providers**.

- Published on the Terraform Registry as [`seekritdev/seekrit`](https://registry.terraform.io/providers/seekritdev/seekrit/latest).
- Manages apps, environments, groups, service tokens, key grants and secrets for [seekrit](https://seekrit.dev), an end-to-end encrypted secrets manager.
- Terraform-specific angle worth the entry: because secret values in `terraform.tfstate` would defeat the point, values are written only through **write-only arguments** (`value_wo`) and read only through **ephemeral resources** — there is no data source that could persist a plaintext. A schema test in the repo fails the build if a plaintext attribute is added.
- MIT, docs generated with `tfplugindocs`, three companion modules ship alongside.

Disclosure: I maintain the provider.