### PR TITLE
ci: replace misspell with typos

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -6,10 +6,14 @@ on:
       - master
     paths:
       - '**.md'
+      - '.typos.toml'
+      - '.github/workflows/misspell.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - '**.md'
+      - '.typos.toml'
+      - '.github/workflows/misspell.yml'
 
 permissions:
   contents: read
@@ -17,9 +21,10 @@ permissions:
 jobs:
   misspell:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: misspell
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1
+      - name: Check Markdown spelling
+        uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
         with:
-          locale: "US"
+          config: .typos.toml

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,12 @@
+[files]
+# Include Markdown recursively, including documentation in hidden directories.
+ignore-hidden = false
+extend-exclude = ["*", "!*/", "!*.md", ".git", "node_modules", "vendor"]
+
+[default]
+locale = "en-us"
+
+[default.extend-words]
+aks = "aks" # Azure Kubernetes Service
+CAF = "CAF" # Azure Cloud Adoption Framework
+yor = "yor" # Infrastructure tagging tool


### PR DESCRIPTION
## Summary
Replace the failing Docker-based misspell action with the official Typos composite action, pinned to v1.50.1. Preserve the `misspell` workflow and job names while making spelling mistakes fail CI.

Check Markdown recursively with US English and three domain-specific exceptions (AKS, CAF, Yor). Include checker/configuration changes in triggers and bound the job to five minutes. No existing prose needed correction; weekly Actions Dependabot updates already cover Typos.

## References
- https://github.com/crate-ci/typos/releases/tag/v1.50.1
- https://github.com/shuaibiyy/awesome-tf/actions/runs/33957757233
