### PR TITLE
providers: add terraform-provider-nxip

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terraform-provider-k8s](https://github.com/banzaicloud/terraform-provider-k8s) - Simple Kubernetes Provider, works with any manifest.
 - [terraform-provider-keycloak](https://github.com/keycloak/terraform-provider-keycloak) - Provider to manage the settings of your [Keycloak](https://www.keycloak.org/) identity provider server.
 - [terraform-provider-linode](https://github.com/btobolaski/terraform-provider-linode) - Provider for Linode.
+- [terraform-provider-nxip](https://github.com/uk-sw/terraform-provider-nxip) - Provider for [nxip](https://nx-ip.com), IPAM with pool-based CIDR allocation across cloud and on-premise. :heavy_dollar_sign:
 - [terraform-provider-openstack](https://github.com/terraform-provider-openstack/terraform-provider-openstack) - Plugin for OpenStack.
 - [terraform-provider-panos](https://github.com/PaloAltoNetworks/terraform-provider-panos) - Provider for [Palo Alto Networks next-generation firewalls](https://www.paloaltonetworks.com/network-security).
 - [terraform-provider-phare](https://github.com/phare/terraform-provider-phare) -  Terraform provider for [Phare](https://phare.io).


### PR DESCRIPTION
Adds nxip to Vendor supported providers, sorted alphabetically between `linode` and `openstack`.

nxip is an IPAM platform where address space is allocated from pools rather than picked by hand: you request a size in an environment and region, and the provider returns a CIDR. Cloud and on-premise, IPv4 and IPv6.

Tagged `:heavy_dollar_sign:` per the legend. There is a free tier, but paid plans exist, so the marker seemed right.

- Provider: https://registry.terraform.io/providers/uk-sw/nxip
- Docs: https://nx-ip.com/docs

Thanks for maintaining the list.