### PR TITLE
fix: handle verified bot-blocked resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Mobile, desktop, and PWA apps for learning and working with Terraform on the go.
 - [Hello, world: The Fargate/Terraform tutorial I wish I had](https://section411.com/2019/07/hello-world/) - Blog post describing setting up an ECS Fargate cluster from scratch
 - [Terraform Security Guide](https://sysdig.com/blog/terraform-security-best-practices/) - Blog post describing security best practices when working with Terraform
 - [Building a SaaS API? Don't Forget Your Terraform Provider](https://www.speakeasy.com/blog/build-terraform-providers) - Why you should write a terraform provider
-- [Complete Terraform Course in French (Free)](https://blog.stephane-robert.info/docs/infra-as-code/provisionnement/terraform/introduction/) – A comprehensive and free course in French to master Terraform, from beginner to advanced usage, with hands-on examples and best practices.
+- [Complete Terraform Course in French (Free)](https://blog.stephane-robert.info/docs/infra-as-code/provisionnement/terraform/) – A comprehensive and free course in French to master Terraform, from beginner to advanced usage, with hands-on examples and best practices.
 - [Introduction to Terraform](https://devopslesson.com/tutorials/terraform/introduction-to-terraform) - Beginner-friendly guide to Terraform fundamentals — providers, resources, state, and your first apply with hands-on examples.
 
 ### Writing Custom Providers

--- a/lychee.toml
+++ b/lychee.toml
@@ -15,6 +15,10 @@ accept = [200, 204, 206, 429]
 
 # Exclude flaky or bot-blocked hosts while keeping links in README
 exclude = [
+  # Verified content on 2026-09-09; Lychee receives bot-blocking 403/202 responses.
+  '^https://blog\.stephane-robert\.info/docs/infra-as-code/provisionnement/terraform/?$',
+  '^https://jfrog\.com/artifactory/?$',
+  '^https://www\.oreilly\.com/library/view/infrastructure-as-code/9781491924334/?$',
   # These pages serve valid content to curl but reject Lychee with 403 (2026-09-06).
   '^https://devopslesson\.com/playground/terraform/?$',
   '^https://devopslesson\.com/tutorials/terraform/introduction-to-terraform/?$',


### PR DESCRIPTION
## Summary

Update the French Terraform course to its current canonical URL and exclude three exact, verified resource URLs that return bot-blocking responses to Lychee (403 for the course and O’Reilly; 202 for JFrog).

The course and JFrog serve content to curl; O’Reilly's book page remains available through browser retrieval. Keep status-code acceptance unchanged so unrelated failures remain visible.

## References

- https://github.com/shuaibiyy/awesome-tf/actions/runs/34342054250
