### PR TITLE
docs: strengthen contribution screening

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe the change. For a new project, explain its Terraform use case and link to documentation/source or other evidence of usability.
+
+## Project submissions
+
+For other changes, remove this section.
+
+Affiliation (maintainer, employer, paid promotion, other relationship, or none):
+
+- [ ] I checked the project URL, or explained blocked access and how to verify it.
+- [ ] The description is neutral, matches the project, and includes documentation/source links where available.
+- [ ] I disclosed my affiliation and checked for an existing entry for this product.
+
+Reviewer: before approving, check the project links and description, disclosure, and enough substantive documentation or usage evidence to justify inclusion. Passing CI alone is insufficient.

--- a/contributing.md
+++ b/contributing.md
@@ -6,3 +6,18 @@
 * Be brave with contributing and commenting.
 * Consider if the item you're adding to the list is actually pretty useful and/or exciting for the Terraform community or newcomers.
 * In case we gather a lot of links that are kinda-useful, but not exactly awesome, we could create another list within the repo.
+
+## Submitting a project
+
+* Self-submissions and commercial projects are welcome. Disclose any material affiliation in the PR: maintaining the project, working for the organization, or being compensated to promote it.
+* Include the canonical HTTPS project/product URL, documentation, and source repository if available. Open source is not required. Briefly explain its Terraform use case and provide a usage example, demo, or other evidence of current availability if the links alone are insufficient.
+* Use a neutral, factual description in the appropriate category. Avoid marketing slogans. A landing page without substantive project information may be declined. Check for existing entries, including other names for the same product; explain why a separate entry is useful.
+* Check the links yourself. If automated access is blocked, explain how a reviewer can verify the resource. A checker failure or temporary outage alone does not establish deception.
+
+## Reviewing a project
+
+New project/tool additions should receive substantive human review before merging; passing CI alone is insufficient. A reviewer should check that the linked project matches the description, has useful documentation (including for proprietary products), and provides reasonable evidence that it exists and is usable. Confirm the category, neutral wording, disclosure, and any material contradictions in the submission.
+
+Consider maintenance context such as release notes, documented limitations, and support information where available. No minimum stars, age, or contributor count is required. New accounts, commercial projects, affiliation, and outages are not grounds on their own to infer abuse. If evidence is insufficient, request clarification or defer inclusion.
+
+Treat bot-blocked or excluded URLs as requiring manual verification. Any new checker exception should be narrowly scoped and explain the independent verification; do not bypass failures merely to obtain a green check.


### PR DESCRIPTION
## Summary

Add concise disclosure, verification, neutral-description, and human-review expectations, plus a short project-submission template. Self-submissions and commercial projects remain welcome; availability and account metadata alone do not establish abuse.

## Validation

- Markdown spelling check and `git diff --check` passed.
- Reviewed against existing categories, including commercial and abandoned resources.
