### PR TITLE
ci: run spelling check for every pull request

### DIFF
--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -9,11 +9,7 @@ on:
       - '.typos.toml'
       - '.github/workflows/misspell.yml'
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - '**.md'
-      - '.typos.toml'
-      - '.github/workflows/misspell.yml'
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Run the existing `misspell` job on every PR, including base changes and ready-for-review events. Removing PR path filters makes it suitable as a required check without leaving non-Markdown PRs waiting for a missing result. Default-branch push filters remain unchanged.

## Validation

- `actionlint`, Markdown spelling check, and `git diff --check` passed.
- Stable job name and unconditional PR job preserved; no new permissions or dependencies.
