### PR TITLE
ci: harden validation for newly introduced links

### DIFF
--- a/.github/scripts/check_new_links.py
+++ b/.github/scripts/check_new_links.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Check newly introduced README URLs with Lychee; leave quality decisions to review."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from urllib.parse import urlsplit
+
+# These responses require independent verification, not a conclusion of unavailability.
+REVIEW_CODES = {202, 401, 403, 429}
+
+
+def extract_urls(path, config):
+    result = subprocess.run(
+        ["lychee", "--config", str(config), "--dump", "--verbose", "--no-progress",
+         "--include", "^https?://", str(path)],
+        check=True, capture_output=True, text=True,
+    )
+    # Verbose dump also includes built-in exclusions (such as example domains).
+    urls = (line.split()[0] for line in result.stdout.splitlines() if line.strip())
+    return {url for url in urls if urlsplit(url).scheme in {"http", "https"}}
+
+
+def classify(report, returncode, urls):
+    """Reject hard failures and incomplete reports; distinguish unverified URLs."""
+    if returncode not in {0, 2}:
+        raise ValueError(f"Lychee failed to run (exit {returncode})")
+    failures, review, seen = [], [], set()
+    for key in ("success_map", "error_map", "timeout_map", "excluded_map"):
+        for entries in report.get(key, {}).values():
+            for entry in entries:
+                url, status = entry["url"], entry["status"]
+                seen.add(url)
+                if key == "excluded_map" or status.get("code") in REVIEW_CODES:
+                    review.append(url)
+                elif key != "success_map":
+                    failures.append(f"{url}: {status['text']}")
+    if seen != set(urls) or report.get("unknown", 0) or report.get("unsupported", 0):
+        raise ValueError("Lychee report is incomplete or contains unsupported results")
+    return failures, sorted(set(review))
+
+
+def check_urls(urls, config):
+    with tempfile.TemporaryDirectory() as directory:
+        temp = Path(directory)
+        inputs = temp / "links.txt"
+        inputs.write_text("\n".join(urls) + "\n")
+        output = temp / "report.json"
+        result = subprocess.run([
+            "lychee", "--config", str(config), "--cache=false", "--no-progress", "--verbose",
+            "--accept", "200,204,206", "--timeout", "20",
+            "--format", "json", "--output", str(output), str(inputs),
+        ], check=False)
+        return classify(json.loads(output.read_text()), result.returncode, urls)
+
+
+def announce(level, message):
+    print(f"{level.upper()}: {message}")
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        escaped = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::{level}::{escaped}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", help="PR base commit SHA")
+    parser.add_argument("head", help="PR head commit SHA")
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory() as directory:
+        temp = Path(directory)
+        # Read exact commits, never merge-base guesses or unrelated base changes.
+        for ref, name in ((args.base, "base.md"), (args.head, "head.md")):
+            content = subprocess.check_output(["git", "show", f"{ref}:README.md"])
+            (temp / name).write_bytes(content)
+        # Use established exclusions. Proposed policy changes need separate review.
+        config = temp / "lychee.toml"
+        config.write_bytes(subprocess.check_output(["git", "show", f"{args.base}:lychee.toml"]))
+        empty_config = temp / "extract.toml"
+        empty_config.write_text("")
+        urls = sorted(extract_urls(temp / "head.md", empty_config)
+                      - extract_urls(temp / "base.md", empty_config))
+        if not urls:
+            announce("notice", "No newly introduced README URLs. Human review still applies to new entries and changed descriptions.")
+            return 0
+        insecure = [url for url in urls if urlsplit(url).scheme != "https"]
+        if insecure:
+            announce("error", "New external URLs must use HTTPS: " + ", ".join(insecure))
+            return 1
+        failures, review = check_urls(urls, config)
+        for url in review:
+            announce("warning", f"Manual verification required (excluded or access/challenge response): {url}")
+        for failure in failures:
+            announce("error", failure)
+        summary = (f"Checked {len(urls)} new URLs: {len(failures)} failures; "
+                   f"{len(review)} require manual verification. Reachability does not establish quality.")
+        announce("notice", summary)
+        if os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as stream:
+                stream.write(summary + "\n\n")
+                # Plain code blocks avoid rendering submitted URLs as HTML in the summary.
+                if review:
+                    stream.write("Review access/challenge responses and exclusions in the warning annotations.\n")
+        return int(bool(failures))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_new_links.py
+++ b/.github/scripts/check_new_links.py
@@ -100,7 +100,7 @@ def main():
         if os.environ.get("GITHUB_STEP_SUMMARY"):
             with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as stream:
                 stream.write(summary + "\n\n")
-                # Plain code blocks avoid rendering submitted URLs as HTML in the summary.
+                # Keep submitted URLs in annotations rather than rendering them as summary HTML.
                 if review:
                     stream.write("Review access/challenge responses and exclusions in the warning annotations.\n")
         return int(bool(failures))

--- a/.github/scripts/test_check_new_links.py
+++ b/.github/scripts/test_check_new_links.py
@@ -1,0 +1,127 @@
+"""Regression tests for URL selection and the failure/manual-review boundary."""
+import http.server
+import threading
+import tempfile
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from check_new_links import check_urls, classify, extract_urls, main
+
+
+class SelectionTests(unittest.TestCase):
+    def test_markdown_forms_and_unchanged_broken_link(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "empty.toml"
+            config.write_text("")
+            base, head = root / "base.md", root / "head.md"
+            base.write_text("- [Old](https://old.invalid/dead) - Old description.\n")
+            head.write_text('''- [Old](https://old.invalid/dead) - Edited description.
+- [New][project]
+[project]: https://new.invalid/tool
+- [Inline](https://new.invalid/a_(b))
+<a href="https://new.invalid/html">HTML</a>
+''')
+            old, new = extract_urls(base, config), extract_urls(head, config)
+            self.assertEqual(len(new - old), 3)
+            self.assertIn("https://new.invalid/tool", new - old)
+            self.assertNotIn("https://old.invalid/dead", new - old)
+            self.assertTrue(any("a_(b)" in url for url in new))
+            head.write_text("- [Old](https://old.invalid/dead) - Edited description.\n")
+            self.assertEqual(extract_urls(head, config) - old, set())
+            head.write_text("- [New](http://new.invalid/tool)\n")
+            self.assertEqual(extract_urls(head, config), {"http://new.invalid/tool"})
+
+
+class EntrypointTests(unittest.TestCase):
+    def run_main(self, head):
+        def git_show(command):
+            if command[-1].endswith(":lychee.toml"):
+                return b""
+            if command[-1].startswith("base:"):
+                return b"- [Old](https://old.invalid/dead) - Old description.\n"
+            return head.encode()
+        with patch("sys.argv", ["check_new_links.py", "base", "head"]), patch(
+            "check_new_links.subprocess.check_output", side_effect=git_show
+        ), patch("check_new_links.check_urls") as network:
+            result = main()
+            network.assert_not_called()
+            return result
+
+    def test_description_only_does_not_check_existing_broken_url(self):
+        self.assertEqual(self.run_main("- [Old](https://old.invalid/dead) - New description.\n"), 0)
+
+    def test_new_http_url_is_rejected(self):
+        self.assertEqual(self.run_main("- [New](http://new.invalid/tool)\n"), 1)
+
+
+class ReportTests(unittest.TestCase):
+    def report(self, key, code=None, text="result"):
+        status = {"text": text}
+        if code is not None:
+            status["code"] = code
+        return {key: {"links.txt": [{"url": "https://tool.test/", "status": status}]}}
+
+    def test_reachable_and_redirect_destination(self):
+        report = self.report("success_map", 200)
+        report["redirect_map"] = {"https://tool.test/": "https://tool.test/docs"}
+        self.assertEqual(classify(report, 0, {"https://tool.test/"}), ([], []))
+
+    def test_hard_network_failures(self):
+        for key, reason in (("error_map", "DNS failure"), ("error_map", "TLS failure"),
+                            ("error_map", "Connection refused"), ("timeout_map", "Timeout"),
+                            ("error_map", "404 Not Found")):
+            with self.subTest(reason=reason):
+                failures, review = classify(self.report(key, text=reason), 2, {"https://tool.test/"})
+                self.assertEqual(len(failures), 1)
+                self.assertEqual(review, [])
+
+    def test_bot_responses_and_exclusions_need_review(self):
+        for code in (202, 401, 403, 429):
+            with self.subTest(code=code):
+                self.assertEqual(classify(self.report("error_map", code), 2, {"https://tool.test/"}),
+                                 ([], ["https://tool.test/"]))
+        self.assertEqual(classify(self.report("excluded_map"), 0, {"https://tool.test/"}),
+                         ([], ["https://tool.test/"]))
+
+    def test_incomplete_report_and_execution_failure(self):
+        for report, code in (({}, 0), (self.report("success_map", 200), 1)):
+            with self.assertRaises(ValueError):
+                classify(report, code, {"https://tool.test/"})
+
+
+class NetworkTests(unittest.TestCase):
+    def test_real_requests_redirects_and_review_responses(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                code = 302 if self.path == "/redirect" else int(self.path[1:])
+                self.send_response(code)
+                if code == 302:
+                    self.send_header("Location", "/200")
+                self.end_headers()
+                self.wfile.write(b"Test resource")
+
+            def log_message(self, *args):
+                pass
+
+        with http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+            worker = threading.Thread(target=server.serve_forever, daemon=True)
+            worker.start()
+            try:
+                with tempfile.TemporaryDirectory() as directory:
+                    config = Path(directory) / "lychee.toml"
+                    config.write_text('max_retries = 0\ntimeout = 2\nexclude = ["/excluded$"]\n')
+                    base = f"http://127.0.0.1:{server.server_port}"
+                    urls = [base + path for path in ("/200", "/redirect", "/401", "/403", "/429", "/202", "/404", "/excluded")]
+                    failures, review = check_urls(urls, config)
+                    self.assertEqual(len(failures), 1)
+                    self.assertIn("/404", failures[0])
+                    self.assertEqual(set(review), {base + path for path in ("/401", "/403", "/429", "/202", "/excluded")})
+            finally:
+                server.shutdown()
+                worker.join()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_check_new_links.py
+++ b/.github/scripts/test_check_new_links.py
@@ -44,7 +44,7 @@ class EntrypointTests(unittest.TestCase):
             return head.encode()
         with patch("sys.argv", ["check_new_links.py", "base", "head"]), patch(
             "check_new_links.subprocess.check_output", side_effect=git_show
-        ), patch("check_new_links.check_urls") as network:
+        ), patch("check_new_links.announce"), patch("check_new_links.check_urls") as network:
             result = main()
             network.assert_not_called()
             return result

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,11 +9,7 @@ on:
       - lychee.toml
       - .github/workflows/link-checker.yml
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - README.md
-      - lychee.toml
-      - .github/workflows/link-checker.yml
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
   schedule:
     - cron: "12 4 * * *"
@@ -54,29 +50,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Extract added README links
-        id: links
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          git diff --unified=0 --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} HEAD -- README.md > readme.diff
-          awk '/^\+[^+]/ { sub(/^\+/, ""); print }' readme.diff \
-            | { grep -Eo 'https?://[^][) <>"]+' || [[ $? == 1 ]]; } \
-            | sed -E 's/[),.;:!?]+$//' \
-            | sort -u > pr-links.txt
-
-          if [[ -s pr-links.txt ]]; then
-            echo "has_links=true" >> "$GITHUB_OUTPUT"
-            cat pr-links.txt
-          else
-            echo "has_links=false" >> "$GITHUB_OUTPUT"
-            echo "No added README links to check."
-          fi
-
-      - name: Link Checker
-        if: steps.links.outputs.has_links == 'true'
+      - name: Set up Lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --config ./lychee.toml pr-links.txt
+          lycheeVersion: v0.24.2
+          args: --version
+          failIfEmpty: false
+          jobSummary: false
+
+      - name: Test added-link validation
+        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
+
+      - name: Check newly introduced README links
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/check_new_links.py "$BASE_SHA" "$HEAD_SHA"


### PR DESCRIPTION
## Summary

Run `check-pr-diff` for every PR and compare README URLs with Lychee's Markdown parser using exact base/head commits. Check only newly introduced URLs, require HTTPS, disable caching, and use the base branch's existing exclusions.

Fail hard network errors; annotate access/challenge responses (202/401/403/429) and excluded URLs for human verification. Keep the scheduled full-list checker unchanged. No account heuristics, new broad exclusions, services, or secrets.

## Validation

- Eight regression tests, including real local HTTP requests, redirects, exclusions, bot responses, Markdown reference/HTML links, unchanged broken URLs, HTTP rejection, and incomplete reports.
- Local HTTPS fixture exercised TLS failure, DNS failure, and connection refusal; its self-signed certificate was bypassed only for fixture response tests.
- Live InfraScan HTTPS succeeded; the existing JFrog exclusion was reported for manual review.
- `actionlint`, spelling check, and `git diff --check` passed.

## Context

After merge, an administrator can require `check-pr-diff` alongside a human approval. Warnings do not constitute verification. Review workflow/configuration edits themselves; PR-controlled workflows are not a tamper-proof gate.
