### PR TITLE
ci: protect contribution screening files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Screening changes need owner review when repository rules require Code Owners.
+# Ordinary README submissions remain under the normal review process.
+/.github/workflows/ @shuaibiyy
+/.github/scripts/ @shuaibiyy
+/.github/CODEOWNERS @shuaibiyy
+/lychee.toml @shuaibiyy
+/.typos.toml @shuaibiyy
+/contributing.md @shuaibiyy
+/.github/pull_request_template.md @shuaibiyy


### PR DESCRIPTION
## Summary

- Assign the verified repository owner, @shuaibiyy, to screening workflows/scripts, policy, templates, checker configuration, and CODEOWNERS itself.
- Leave README submissions outside owner-specific review. Enforcement requires an administrator to enable Code Owner review in repository rules.

## Validation

- Checked anchored paths against the repository tree; README.md is not matched.
- Confirmed repository ownership through GitHub; spelling and diff checks passed.
