### PR TITLE
ci: run PR link validation from trusted base

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -60,11 +61,33 @@ jobs:
           failIfEmpty: false
           jobSummary: false
 
-      - name: Test added-link validation
-        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
-
-      - name: Check newly introduced README links
+      # Keep PR code and tests off the enforcement runner.
+      - name: Check newly introduced README links with the base validator
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python3 .github/scripts/check_new_links.py "$BASE_SHA" "$HEAD_SHA"
+        run: |
+          git fetch --no-tags origin "$HEAD_SHA"
+          git show "$BASE_SHA:.github/scripts/check_new_links.py" > "$RUNNER_TEMP/check_new_links.py"
+          python3 -I "$RUNNER_TEMP/check_new_links.py" "$BASE_SHA" "$HEAD_SHA"
+
+  validator-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # Development tests exercise proposed code on a separate, read-only runner.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          lycheeVersion: v0.24.2
+          args: --version
+          failIfEmpty: false
+          jobSummary: false
+
+      - name: Test proposed added-link validation
+        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'


### PR DESCRIPTION
## Summary

- Run required added-link validation using the validator from the PR base revision so a PR cannot weaken the validation logic evaluating its own README changes.
- Keep the enforcement checkout at the base SHA, fetch the exact head as data, and execute the base validator from runner temporary storage with isolated Python imports.
- Move proposed-code tests to a separate read-only runner. Preserve `check-pr-diff`, existing events, and pinned actions; workflow edits still need enforced Code Owner review.

## Validation

- Eight validator tests, actionlint, spelling, and diff checks passed.
- Temporary Git fixtures: reachable HTTPS passes; dead URL fails even with an always-successful head validator and a new blanket exclusion; bot-blocked response warns for manual review.
