### PR TITLE
Add TerraDrift to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ For more Community Modules not listed here please see the [Terraform Module Regi
 - [terracost](https://github.com/cycloidio/terracost) - Cloud cost estimation for Terraform in your CLI.
 - [terracove](https://elementtech.github.io/terracove/) - Recursively test a directory tree for Terraform diffs and coverage.
 - [TerraDepot](https://github.com/derBroBro/TerraDepot) - Terraform state repository, based on the default http remote backend. Allows the central administration of tfstates on AWS S3.
+- [TerraDrift](https://github.com/niravraychura/terradrift) - Self-hosted Terraform/OpenTofu drift CLI for CI and cron (plan-based; not unmanaged-resource inventory).
 - [terradozer](https://github.com/chenrui333/terradozer) - Terraform destroy without configuration files.
 - [terraeasy](https://github.com/jaceq/terraeasy) - Easy Terraform wrapper
 - [terraform-ai-skills](https://github.com/anmolnagpal/terraform-ai-skills) - AI-powered skill for GitHub Copilot, Claude, and ChatGPT that automates bulk Terraform module management — provider upgrades, workflow standardization, and releases across 10–200+ repositories on AWS, GCP, Azure, and DigitalOcean.


### PR DESCRIPTION
## Summary
Adds [TerraDrift](https://github.com/niravraychura/terradrift) under Tools (alphabetically after TerraDepot). It is a self-hosted Terraform/OpenTofu **plan-based** drift CLI for CI and cron, not unmanaged-resource inventory (unlike driftctl).

**Affiliation:** I maintain TerraDrift.

## Evidence
- Source: https://github.com/niravraychura/terradrift
- Latest release: https://github.com/niravraychura/terradrift/releases/tag/v0.4.0
- Docs: https://github.com/niravraychura/terradrift/blob/main/README.md
- Comparison: https://github.com/niravraychura/terradrift/blob/main/docs/COMPARE.md